### PR TITLE
Add option to bind to specific network interface

### DIFF
--- a/cnping.c
+++ b/cnping.c
@@ -652,6 +652,7 @@ int main( int argc, const char ** argv )
 	double LastFrameTime = OGGetAbsoluteTime();
 	double SecToWait;
 	double frameperiodseconds;
+	const char * device = NULL;
 
 #ifdef WIN32
 	ShowWindow (GetConsoleWindow(), SW_HIDE);
@@ -704,6 +705,7 @@ int main( int argc, const char ** argv )
 				case 'y': GuiYScaleFactor = atof( nextargv ); break;
 				case 't': sprintf(title, "%s", nextargv); break;
 				case 'm': in_histogram_mode = 1; break;
+				case 'I': device = nextargv; break;
 				default: displayhelp = 1; break;
 			}
 		}
@@ -744,7 +746,8 @@ int main( int argc, const char ** argv )
 			"   (-p) [period]               -- period in seconds (optional), default 0.02 \n"
 			"   (-s) [extra size]           -- ping packet extra size (above 12), optional, default = 0 \n"
 			"   (-y) [const y-axis scaling] -- use a fixed scaling factor instead of auto scaling (optional)\n"
-			"   (-t) [window title]         -- the title of the window (optional)\n");
+			"   (-t) [window title]         -- the title of the window (optional)\n"
+			"   (-I) [interface]            -- Sets source interface (i.e. eth0)\n");
 		return -1;
 	}
 
@@ -766,7 +769,7 @@ int main( int argc, const char ** argv )
 	}
 	else
 	{
-		ping_setup();
+		ping_setup(device);
 		OGCreateThread( PingSend, 0 );
 		OGCreateThread( PingListen, 0 );
 	}

--- a/cnping.c
+++ b/cnping.c
@@ -752,6 +752,12 @@ int main( int argc, const char ** argv )
 	}
 
 #if defined( WIN32 ) || defined( WINDOWS )
+	if(device)
+	{
+		ERRM("Error: Device option is not implemented on your platform. PRs welcome.\n");
+		exit( -1 );
+	}
+	
 	if( WSAStartup(MAKEWORD(2,2), &wsaData) )
 	{
 		ERRM( "Fault in WSAStartup\n" );

--- a/cnping.c
+++ b/cnping.c
@@ -771,7 +771,7 @@ int main( int argc, const char ** argv )
 
 	if( memcmp( pinghost, "http://", 7 ) == 0 )
 	{
-		StartHTTPing( pinghost+7, pingperiodseconds );
+		StartHTTPing( pinghost+7, pingperiodseconds, device );
 	}
 	else
 	{

--- a/httping.c
+++ b/httping.c
@@ -102,7 +102,7 @@ reconnect:
 	{
 		if( setsockopt(httpsock, SOL_SOCKET, SO_BINDTODEVICE, device, strlen(device) +1) != 0)
 		{
-			ERRM("Error: Failed to set Device option.  Are you root?  Or can do sock_raw sockets?\n");
+			ERRM("Error: Failed to set Device option.\n");
 			exit( -1 );
 		}
 	}

--- a/httping.h
+++ b/httping.h
@@ -6,7 +6,7 @@ void HTTPingCallbackStart( int seqno );
 void HTTPingCallbackGot( int seqno );
 
 //addy should be google.com/blah or something like that.  Do not include prefixing http://.  Port numbers OK.
-int StartHTTPing( const char * addy, double minperiod );
+int StartHTTPing( const char * addy, double minperiod, const char * device);
 
 #endif
 

--- a/ping.c
+++ b/ping.c
@@ -47,8 +47,9 @@ struct sockaddr_in psaddr;
 static og_sema_t s_disp;
 static og_sema_t s_ping;
 
-void ping_setup()
+void ping_setup(const char * device)
 {
+
 	s_disp = OGCreateSema();
 	s_ping = OGCreateSema();
 	//This function is executed first.

--- a/ping.c
+++ b/ping.c
@@ -8,6 +8,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/socket.h>
 #include "ping.h"
 #include "error_handling.h"
 
@@ -364,7 +365,7 @@ void ping(struct sockaddr_in *addr )
 	//close( sd ); //Hacky, we don't close here because SD doesn't come from here, rather  from ping_setup.  We may want to run this multiple times.
 }
 
-void ping_setup()
+void ping_setup(const char * device)
 {
 	pid = getpid();
 
@@ -397,6 +398,15 @@ void ping_setup()
 	{
 		ERRM("Error: Failed to set TTL option.  Are you root?  Or can do sock_raw sockets?\n");
 		exit( -1 );
+	}
+
+	if(device)
+	{
+		if( setsockopt(sd, SOL_SOCKET, SO_BINDTODEVICE, device, strlen(device) +1) != 0)
+		{
+			ERRM("Error: Failed to set Device option.  Are you root?  Or can do sock_raw sockets?\n");
+			exit( -1 );
+		}
 	}
 
 #endif

--- a/ping.c
+++ b/ping.c
@@ -8,7 +8,6 @@
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/socket.h>
 #include "ping.h"
 #include "error_handling.h"
 
@@ -164,7 +163,7 @@ void ping(struct sockaddr_in *addr )
 	#include <winsock2.h>
 	#include <ws2tcpip.h>
 	#include <stdint.h>
-#else
+#else // ! WIN32
 	#ifdef __FreeBSD__
 		#include <netinet/in.h>
 	#endif

--- a/ping.h
+++ b/ping.h
@@ -22,7 +22,7 @@ void do_pinger( const char * strhost );
 extern float pingperiodseconds;
 extern int precise_ping; //if 0, use minimal CPU, but ping send-outs are only approximate, if 1, spinlock until precise time for ping is hit.
 extern int ping_failed_to_send;
-void ping_setup();
+void ping_setup(const char * device);
 
 
 #endif


### PR DESCRIPTION
As suggested in  #67 i implemented a `-I` option to choose the network interface.
After looking into the source code of ping it seemed stright forword (just one `setsockopt`).
https://github.com/iputils/iputils/blob/master/ping/ping.c#L618

A few problems still need to be addressed:
* The `<sys/socket.h>` include wont work with windows. In which of the `#ifdef` should that be added?
* What is with the CLI argument on windows? should that be hidden, since it is currently a "linux only" feature?
* This HTTP-Ping ignores the device selection. Is that a problem? Is it useful to have a interface selection on HTTP-Ping?

Test with a wireguard VPN and normal ethernet interface:
![grafik](https://user-images.githubusercontent.com/8640309/185360570-b3366d01-7211-4e94-901f-4abb3a0739b9.png)
