### PR TITLE
Add IPv6 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ ADMINFLAGS:= $(ADMINFLAGS) -DWIN_USE_NO_ADMIN_PING
 cnping-wingdi.exe : cnping.c ping.c httping.c resources.o
 	$(MINGW32)gcc -g -fno-ident -mwindows -m32 $(CFLAGS) -o $@ $^  -lgdi32 -lws2_32 -s -D_WIN32_WINNT=0x0600 -DWIN32 -liphlpapi -DMINGW_BUILD $(ADMINFLAGS)
 
-cnping.exe : cnping.c ping.c httping.c resources.o
+cnping.exe : cnping.c ping.c httping.c resolve.c resources.o
 	$(MINGW32)gcc -g -fno-ident -mwindows -m32 -DCNFGOGL $(CFLAGS) -o $@ $^  -lgdi32 -lws2_32 -s -D_WIN32_WINNT=0x0600 -DWIN32 -liphlpapi -lopengl32 -DMINGW_BUILD $(ADMINFLAGS)
 
 resources.o : resources.rc
@@ -32,13 +32,13 @@ resources.o : resources.rc
 
 # Unix
 
-cnping : cnping.c ping.c httping.c
+cnping : cnping.c ping.c httping.c resolve.c
 	$(CC) $(CFLAGS) -o $@ $^ -lX11 -lm -lpthread -lGL $(LDFLAGS)
 
-cnping_ogl : cnping.c ping.c httping.c
-	$(CC) $(CFLAGS) -o $@ $^ -DCNFGOGL $(CFLAGS) -s -lX11 -lm -lpthread $(LDFLAGS) -lGL
+cnping_ogl : cnping.c ping.c httping.c resolve.c
+	$(CC) $(CFLAGS) -o $@ $^ -DCNFGOGL $(CFLAGS) -lX11 -lm -lpthread $(LDFLAGS) -lGL
 
-cnping_mac : cnping.c ping.c httping.c
+cnping_mac : cnping.c ping.c httping.c resolve.c
 	$(CC) -o cnping $^ -x objective-c -framework Cocoa -framework QuartzCore -lm -lpthread -DOSX
 
 searchnet : ping.o searchnet.o

--- a/cnping.c
+++ b/cnping.c
@@ -194,7 +194,7 @@ void * PingListen( void * r )
 
 void * PingSend( void * r )
 {
-	do_pinger( pinghost );
+	do_pinger( );
 	ERRM( "Fault on ping.\n" );
 	exit( -1 );
 }
@@ -775,7 +775,7 @@ int main( int argc, const char ** argv )
 	}
 	else
 	{
-		ping_setup(device);
+		ping_setup( pinghost, device );
 		OGCreateThread( PingSend, 0 );
 		OGCreateThread( PingListen, 0 );
 	}

--- a/cnping.c
+++ b/cnping.c
@@ -804,14 +804,7 @@ int main( int argc, const char ** argv )
 
 		CNFGPenX = 100; CNFGPenY = 100;
 		CNFGColor( 0xff0000ff );
-		if( ping_failed_to_send )
-		{
-			CNFGDrawText( "Could not send ping.\nIs target reachable?\nDo you have sock_raw to privileges?", 3 );
-		}
-		else
-		{
-			CNFGDrawText( errbuffer, 3 );
-		}
+		CNFGDrawText( errbuffer, 3 );
 
 
 		frames++;

--- a/httping.c
+++ b/httping.c
@@ -16,7 +16,7 @@
 #if defined( WIN32 ) || defined( WINDOWS )
 	#ifdef TCC
 	#else
-	#include <winsock2.h>
+	#include <ws2tcpip.h>
 	#endif
 #else
 	#include <sys/socket.h>

--- a/httping.c
+++ b/httping.c
@@ -80,7 +80,7 @@ void DoHTTPing( const char * addy, double minperiod, int * seqnoptr, volatile do
 	/* gethostbyname: get the server's DNS entry */
 	serveraddr_len = sizeof(serveraddr);
 	*getting_host_by_name = 1;
-	serverresolve = resolveName((struct sockaddr*) &serveraddr, &serveraddr_len, hostname);
+	serverresolve = resolveName((struct sockaddr*) &serveraddr, &serveraddr_len, hostname, AF_UNSPEC);
 	*getting_host_by_name = 0;
 
 	if (serverresolve != 1) {

--- a/ping.c
+++ b/ping.c
@@ -54,7 +54,7 @@ void ping_setup(const char * strhost, const char * device)
 {
 	// resolve host
 	psaddr_len = sizeof(psaddr);
-	resolveName((struct sockaddr*) &psaddr, &psaddr_len, strhost);
+	resolveName((struct sockaddr*) &psaddr, &psaddr_len, strhost, AF_INET); // only resolve ipv4 on windows
 
 	s_disp = OGCreateSema();
 	s_ping = OGCreateSema();
@@ -133,7 +133,7 @@ void ping(struct sockaddr *addr, socklen_t addr_len )
 	{
 		// ipv6 ICMP Ping is not supported on windows
 		ERRM( "ERROR: ipv6 ICMP Ping is not supported on windows\n" );
-		return;
+		exit( -1 );
 	}
 
 	//Launch pinger threads
@@ -463,7 +463,7 @@ void ping_setup(const char * strhost, const char * device)
 #else
 	// resolve host
 	psaddr_len = sizeof(psaddr);
-	resolveName((struct sockaddr*) &psaddr, &psaddr_len, strhost);
+	resolveName((struct sockaddr*) &psaddr, &psaddr_len, strhost, AF_UNSPEC);
 
 	sd = createSocket();
 

--- a/ping.c
+++ b/ping.c
@@ -284,10 +284,7 @@ int isICMPResponse(unsigned char* buf, int bytes)
 	}
 	else if( psaddr.sin6_family == AF_INET6 ) // ipv6 compare
 	{
-		if( buf[0] != ICMP6_ECHO_REPLY ) {
-			printf("buf[0] failed\n");
-			return 0;
-		}
+		if( buf[0] != ICMP6_ECHO_REPLY ) return 0;
 	}
 
 	return 1;
@@ -410,7 +407,7 @@ void ping(struct sockaddr *addr, socklen_t addr_len )
 		if( sr <= 0 )
 		{
 			ping_failed_to_send = 1;
-			ERRM("Ping send failed: %s errno: %d\n", strerror(errno), errno);
+			ERRMB("Ping send failed:\n%s (%d)\n", strerror(errno), errno);
 		}
 		else
 		{

--- a/ping.h
+++ b/ping.h
@@ -4,11 +4,10 @@
 #include <stdint.h>
 #ifdef WIN32
 	typedef int socklen_t;
+	struct sockaddr;
 #else
 	#include <sys/socket.h>
 #endif
-
-struct sockaddr_in;
 
 unsigned short checksum(const unsigned char *b, uint16_t len);
 

--- a/ping.h
+++ b/ping.h
@@ -2,6 +2,7 @@
 #define _PING_H
 
 #include <stdint.h>
+#include <sys/socket.h> // for socklen_t
 
 struct sockaddr_in;
 
@@ -15,14 +16,14 @@ void display(uint8_t *buf, int bytes);
 int load_ping_packet( uint8_t  * buffer, int buffersize );
 
 void listener();
-void ping(struct sockaddr_in *addr );
-void do_pinger( const char * strhost );
+void ping(struct sockaddr *addr, socklen_t addr_len );
+void do_pinger( );
 
 //If pingperiodseconds = -1, run ping/do_pinger once and exit.
 extern float pingperiodseconds;
 extern int precise_ping; //if 0, use minimal CPU, but ping send-outs are only approximate, if 1, spinlock until precise time for ping is hit.
 extern int ping_failed_to_send;
-void ping_setup(const char * device);
+void ping_setup(const char * strhost, const char * device);
 
 
 #endif

--- a/ping.h
+++ b/ping.h
@@ -2,7 +2,11 @@
 #define _PING_H
 
 #include <stdint.h>
-#include <sys/socket.h> // for socklen_t
+#ifdef WIN32
+	typedef int socklen_t;
+#else
+	#include <sys/socket.h>
+#endif
 
 struct sockaddr_in;
 

--- a/resolve.c
+++ b/resolve.c
@@ -1,0 +1,63 @@
+#include "resolve.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "error_handling.h"
+
+#ifdef WIN32
+
+#else // !WIN32
+	#include <arpa/inet.h> // inet_pton (parsing ipv4 and ipv6 notation)
+
+	#include <sys/types.h>
+	#include <sys/socket.h>
+	#include <netdb.h>
+#endif
+
+int resolveName(struct sockaddr* addr, socklen_t* addr_len, const char* hostname)
+{
+	int result;
+	struct addrinfo* res = NULL;
+
+	// zero addr
+	memset(addr, 0, *addr_len);
+
+	// try to parse ipv4
+	result = inet_pton(AF_INET, hostname, &((struct sockaddr_in*) addr)->sin_addr);
+	if(result == 1)
+	{
+		addr->sa_family = AF_INET;
+		*addr_len = sizeof(struct sockaddr_in);
+		return 1;
+	}
+
+	// try to parse ipv6
+	result = inet_pton(AF_INET6, hostname, &((struct sockaddr_in6*) addr)->sin6_addr);
+	if(result == 1)
+	{
+		addr->sa_family = AF_INET6;
+		*addr_len = sizeof(struct sockaddr_in6);
+		return 1;
+	}
+
+	// try to resolve DNS
+	result = getaddrinfo(hostname, NULL, NULL, &res);
+	if( result != 0)
+	{
+		ERRM( "Error: cannot resolve hostname %s: %s\n", hostname, gai_strerror(result) );
+		exit( -1 );
+	}
+
+	if(res->ai_addrlen > *addr_len)
+	{
+		// error - this should not happen
+		freeaddrinfo(res);
+		exit( -1 );
+	}
+	memcpy(addr, res->ai_addr, res->ai_addrlen);
+	*addr_len = res->ai_addrlen;
+
+	freeaddrinfo(res);
+	return 1;
+}

--- a/resolve.c
+++ b/resolve.c
@@ -6,7 +6,7 @@
 #include "error_handling.h"
 
 #ifdef WIN32
-
+	#include <ws2tcpip.h>
 #else // !WIN32
 	#include <arpa/inet.h> // inet_pton (parsing ipv4 and ipv6 notation)
 

--- a/resolve.c
+++ b/resolve.c
@@ -52,6 +52,7 @@ int resolveName(struct sockaddr* addr, socklen_t* addr_len, const char* hostname
 	if(res->ai_addrlen > *addr_len)
 	{
 		// error - this should not happen
+		ERRM( "Error addr is to short. required length: %d, available length: %d", res->ai_addrlen, *addr_len );
 		freeaddrinfo(res);
 		exit( -1 );
 	}

--- a/resolve.h
+++ b/resolve.h
@@ -1,0 +1,17 @@
+#ifndef _RESOLVE_H
+#define _RESOLVE_H
+
+#ifdef WIN32
+	typedef int socklen_t;
+#else
+	#include <sys/socket.h>
+#endif
+
+// try to parse hostname
+//  * as dot notation (1.1.1.1)
+//  * as ipv6 notation (abcd:ef00::1)
+//  * as hostname (resolve DNS)
+// returns 1 on success
+int resolveName(struct sockaddr* addr, socklen_t* addr_len, const char* hostname);
+
+#endif

--- a/resolve.h
+++ b/resolve.h
@@ -3,6 +3,7 @@
 
 #ifdef WIN32
 	typedef int socklen_t;
+	struct sockaddr;
 #else
 	#include <sys/socket.h>
 #endif

--- a/resolve.h
+++ b/resolve.h
@@ -13,6 +13,7 @@
 //  * as ipv6 notation (abcd:ef00::1)
 //  * as hostname (resolve DNS)
 // returns 1 on success
-int resolveName(struct sockaddr* addr, socklen_t* addr_len, const char* hostname);
+// family can be used to force ipv4 or ipv6. Use AF_UNSPEC (allow both), AF_INET or AF_INET6 to force ipv4 or ipv6
+int resolveName(struct sockaddr* addr, socklen_t* addr_len, const char* hostname, int family);
 
 #endif


### PR DESCRIPTION
This adds IPv6 support as mentioned in #39 .
It works on Linux with ICMP and HTTP-Ping. (Of cause IPv4 still works)

You can enter a host by its ipv4 address (`1.1.1.1`), its ipv6 address (`2a03:4000:2b:41f::4`) or by its hostname (`ipv4.mrbesen.de` or `ipv6.mrbesen.de`).
HTTP ping still works just by prepending `http://` and the Device option (`-I`) also works.

To allow for resolving ipv6 addresses i moved from `gethostbyname()` to `getaddrinfo()`. All the code for resolving the address is in `resolve.c`.

I could not get it to work on Windows. I tried different ways of compiling the code for windows. Crosscompiling it with Mingw created a exe file that kinda worked with wine but straight up crashed on my win10 vm (no matter the arguments). I implemented the old `gethostbyname()` resolve method for windows but it did not help. I have no experience developing C-Applications on Windows and i have no idea where to start the debugging, or even how or which debugger to use on Windows.

Maybe someone more "Windows-experienced" can take a look on the windows side of this PR.

I have not added any way of forcing ipv6 or ipv4 (for example a `-4` or `-6` option) the only way would be to just use the plain address instead of the hostname. I think that is fine for now and would be fairly easy to implement, because `getaddrinfo()` allows for a hint which can force the resolver to focus on ipv4 or ipv6.


P.S: 
Feel free to use my server as test target (`ipv4.mrbesen.de`, `ipv6.mrbesen.de` and `mrbesen.de`)