### PR TITLE
fix http ping

### DIFF
--- a/httping.c
+++ b/httping.c
@@ -21,7 +21,8 @@
 #else
 	#include <sys/socket.h>
 	#include <netinet/in.h>
-	#include <netdb.h> 
+	#include <netinet/tcp.h>
+	#include <netdb.h>
 #endif
 
 #include "rawdraw/os_generic.h"
@@ -99,6 +100,12 @@ reconnect:
 		return;
 	}
 
+	int sockVal = 1;
+	if (setsockopt(httpsock, SOL_TCP, TCP_NODELAY, &sockVal, 4) != 0) {
+		ERRM ( "Error: Failed to set TCP_NODELAY\n");
+		// not a critical error, we can continue
+	}
+
 #if !defined( WIN32 ) && !defined( WINDOWS )
 	if(device)
 	{
@@ -128,7 +135,7 @@ reconnect:
 	{
 		char buf[8192];
 
-		int n = sprintf( buf, "HEAD %s HTTP/1.1\r\nConnection: keep-alive\r\n\r\n", eurl?eurl:"/favicon.ico" );
+		int n = sprintf( buf, "HEAD %s HTTP/1.1\r\nConnection: keep-alive\r\nHost: %s\r\n\r\n", eurl?eurl:"/favicon.ico", hostname );
 		int rs = send( httpsock, buf, n, MSG_NOSIGNAL );
 		double starttime = *timeouttime = OGGetAbsoluteTime();
 		int breakout = 0;

--- a/httping.c
+++ b/httping.c
@@ -18,6 +18,7 @@
 	#else
 	#include <ws2tcpip.h>
 	#endif
+	#define SOL_TCP IPPROTO_TCP
 #else
 	#include <sys/socket.h>
 	#include <netinet/in.h>
@@ -98,7 +99,8 @@ reconnect:
 	}
 
 	int sockVal = 1;
-	if (setsockopt(httpsock, SOL_TCP, TCP_NODELAY, &sockVal, 4) != 0)
+	// using char* for sockVal for windows
+	if (setsockopt(httpsock, SOL_TCP, TCP_NODELAY, (char*) &sockVal, 4) != 0)
 	{
 		ERRM( "Error: Failed to set TCP_NODELAY\n");
 		// not a critical error, we can continue
@@ -113,7 +115,7 @@ reconnect:
 			exit( -1 );
 		}
 	}
-#endif
+#endif // not windows
 
 	/* connect: create a connection with the server */
 	if (connect(httpsock, (struct sockaddr*)&serveraddr, serveraddr_len) < 0)

--- a/httping.c
+++ b/httping.c
@@ -64,9 +64,6 @@ void DoHTTPing( const char * addy, double minperiod, int * seqnoptr, volatile do
 
 	int portno = 80;
 
-	(*seqnoptr) ++;
-	HTTPingCallbackStart( *seqnoptr );
-
 	if( eportmarker )
 	{
 		portno = atoi( eportmarker+1 );
@@ -137,6 +134,10 @@ reconnect:
 		char buf[8192];
 
 		int n = sprintf( buf, "HEAD %s HTTP/1.1\r\nConnection: keep-alive\r\nHost: %s\r\n\r\n", eurl?eurl:"/favicon.ico", hostname );
+
+		(*seqnoptr) ++;
+		HTTPingCallbackStart( *seqnoptr );
+
 		int rs = send( httpsock, buf, n, MSG_NOSIGNAL );
 		double starttime = *timeouttime = OGGetAbsoluteTime();
 		int breakout = 0;
@@ -175,8 +176,6 @@ reconnect:
 		double delay_time = minperiod - (*timeouttime - starttime);
 		if( delay_time > 0 )
 			usleep( (int)(delay_time * 1000000) );
-		(*seqnoptr) ++;
-		HTTPingCallbackStart( *seqnoptr );
 		if( !breakout ) {
 #ifdef WIN32
 			closesocket( httpsock );

--- a/httping.c
+++ b/httping.c
@@ -101,8 +101,9 @@ reconnect:
 	}
 
 	int sockVal = 1;
-	if (setsockopt(httpsock, SOL_TCP, TCP_NODELAY, &sockVal, 4) != 0) {
-		ERRM ( "Error: Failed to set TCP_NODELAY\n");
+	if (setsockopt(httpsock, SOL_TCP, TCP_NODELAY, &sockVal, 4) != 0)
+	{
+		ERRM( "Error: Failed to set TCP_NODELAY\n");
 		// not a critical error, we can continue
 	}
 


### PR DESCRIPTION
fixes the strange HTTP-ping behavior seen in #84.

After observing the connection with wireshark i noticed, that the webserver closed the connection after each ping which made each other ping reconnect (I dont know why its <1ms ping time then).
I fixed this by just adding the `Host: ...` Header to the HTTP Request.

I also added the `TCP_NODELAY` flag. It worked without, but i dont think it will hurt here, because we actually want every `send()` syscall to create a tcp-fragment no matter the size.

The first Ping is still higher than the rest. I think that is because the first Ping time contains 2 Roundtrips (1 roundtrip TCP-Handshake + 1 Roundtrip HTTP-Request/Response).
